### PR TITLE
🗑️ /api/hoge エンドポイントを削除

### DIFF
--- a/dev/backend/main.py
+++ b/dev/backend/main.py
@@ -16,6 +16,3 @@ app.add_middleware(
 async def hello():
     return {"message": "Hello from FastAPI!"}
 
-@app.get("/api/hoge")
-async def hoge():
-    return "hogehoge"


### PR DESCRIPTION
# 概要

Issue #11の要求に従い、不要な `/api/hoge` エンドポイントを削除しました。

# 細かな変更点

- `dev/backend/main.py` から `/api/hoge` エンドポイントとそのハンドラー関数を削除
- 関連するテストコードの確認を行ったが、該当するテストコードは存在しませんでした

# 影響範囲・懸念点

- `/api/hoge` エンドポイントへのリクエストは404エラーになります
- 現在このエンドポイントを利用しているフロントエンド側のコードがないことを確認済み

# おこなった動作確認

- [x] ローカル環境での動作確認（FastAPIが正常に起動することを確認）
- [x] 削除対象エンドポイントの完全削除確認
- [x] 他のエンドポイント（/api/hello）への影響がないことを確認

# その他

resolves #11